### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: php
+
+php:
+  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
+
+before_script:
+  - composer update
+  - composer dump-autoload -o
+
+script: vendor/bin/phpunit
+
+notifications:
+  email:
+    - dave@opulencephp.com
+
+sudo: false
+
+matrix:
+  fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,6 @@ before_script:
 
 script: vendor/bin/phpunit
 
-notifications:
-  email:
-    - dave@opulencephp.com
-
 sudo: false
 
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -11,14 +11,22 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0"
+        "php": ">=5.5.0"
+    },
+    "suggest": {
+        "ext-openssl": "It can help generator to get key with random bytes"
     },
     "autoload": {
         "psr-4": {
             "Keygen\\": "src/Keygen"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Keygen\\Tests\\": "tests/Keygen"
+        }
+    },
     "require-dev": {
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,12 @@
+<phpunit
+    bootstrap="vendor/autoload.php"
+    colors="true">
+    <testsuite name="Keygen">
+        <directory>tests/Keygen</directory>
+    </testsuite>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src/Keygen</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/Keygen/AbstractGeneratorTest.php
+++ b/tests/Keygen/AbstractGeneratorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Keygen\Tests;
+
 use Keygen\Keygen;
 use PHPUnit\Framework\TestCase;
 use Keygen\Generators\NumericGenerator;
@@ -90,7 +92,7 @@ final class AbstractGeneratorTest extends TestCase
 	 * @covers ::__call
 	 * @covers Keygen\Traits\KeyManipulation::__overloadMethods
 	 * @covers Keygen\Traits\KeyManipulation::prefix
-	 * @covers Keygen\Traits\IntegerCasting::affix
+	 * @covers Keygen\Traits\KeyManipulation::affix
 	 */
 	public function testPrefixWithValidArgument()
 	{
@@ -111,7 +113,7 @@ final class AbstractGeneratorTest extends TestCase
 	 * @covers ::__call
 	 * @covers Keygen\Traits\KeyManipulation::__overloadMethods
 	 * @covers Keygen\Traits\KeyManipulation::prefix
-	 * @covers Keygen\Traits\IntegerCasting::affix
+	 * @covers Keygen\Traits\KeyManipulation::affix
 	 * @expectedException \InvalidArgumentException
 	 * @expectedExceptionMessage The given prefix cannot be converted to a string.
 	 */
@@ -124,7 +126,7 @@ final class AbstractGeneratorTest extends TestCase
 	 * @covers ::__call
 	 * @covers Keygen\Traits\KeyManipulation::__overloadMethods
 	 * @covers Keygen\Traits\KeyManipulation::suffix
-	 * @covers Keygen\Traits\IntegerCasting::affix
+	 * @covers Keygen\Traits\KeyManipulation::affix
 	 */
 	public function testSuffixWithValidArgument()
 	{
@@ -145,7 +147,7 @@ final class AbstractGeneratorTest extends TestCase
 	 * @covers ::__call
 	 * @covers Keygen\Traits\KeyManipulation::__overloadMethods
 	 * @covers Keygen\Traits\KeyManipulation::suffix
-	 * @covers Keygen\Traits\IntegerCasting::affix
+	 * @covers Keygen\Traits\KeyManipulation::affix
 	 * @expectedException \InvalidArgumentException
 	 * @expectedExceptionMessage The given suffix cannot be converted to a string.
 	 */

--- a/tests/Keygen/GeneratorFactoryTest.php
+++ b/tests/Keygen/GeneratorFactoryTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Keygen\Tests;
+
 use Keygen\GeneratorFactory;
 use PHPUnit\Framework\TestCase;
 use Keygen\Generators\TokenGenerator;

--- a/tests/Keygen/GeneratorTest.php
+++ b/tests/Keygen/GeneratorTest.php
@@ -1,12 +1,14 @@
 <?php
 
+namespace Keygen\Tests;
+
 use Keygen\Generator;
 use PHPUnit\Framework\TestCase;
 use Keygen\Generators\NumericGenerator;
 
 /**
  * @coversDefaultClass Generator
- * @covers GeneratorInterface
+ * @covers Keygen\GeneratorInterface
  */
 final class GeneratorTest extends TestCase
 {
@@ -18,7 +20,7 @@ final class GeneratorTest extends TestCase
 	}
 
 	/**
-	 * @covers ::generate
+	 * @covers Keygen\GeneratorInterface::generate
 	 * @covers Keygen\Traits\KeyManipulation::getAdjustedKeyLength
 	 */
 	public function testGenerateMethod()

--- a/tests/Keygen/Generators/AlphaNumericGeneratorTest.php
+++ b/tests/Keygen/Generators/AlphaNumericGeneratorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Keygen\Tests;
+
 use PHPUnit\Framework\TestCase;
 use Keygen\Generators\AlphaNumericGenerator;
 
@@ -16,7 +18,7 @@ final class AlphaNumericGeneratorTest extends TestCase
 	}
 
 	/**
-	 * @covers ::keygen
+	 * @covers Keygen\Generator::keygen
 	 * @covers Keygen\Generator::generate
 	 */
 	public function testKeyGeneration()

--- a/tests/Keygen/Generators/NumericGeneratorTest.php
+++ b/tests/Keygen/Generators/NumericGeneratorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Keygen\Tests;
+
 use PHPUnit\Framework\TestCase;
 use Keygen\Generators\NumericGenerator;
 
@@ -16,7 +18,7 @@ final class NumericGeneratorTest extends TestCase
 	}
 
 	/**
-	 * @covers ::keygen
+	 * @covers Keygen\Generator::keygen
 	 * @covers Keygen\Generator::generate
 	 */
 	public function testKeyGeneration()

--- a/tests/Keygen/Generators/RandomByteGeneratorTest.php
+++ b/tests/Keygen/Generators/RandomByteGeneratorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Keygen\Tests;
+
 use PHPUnit\Framework\TestCase;
 use Keygen\Generators\RandomByteGenerator;
 
@@ -16,9 +18,8 @@ final class RandomByteGeneratorTest extends TestCase
 	}
 
 	/**
-	 * @covers ::hex
-	 * @covers ::keygen
-	 * @covers ::generate
+	 * @covers Keygen\Generators\RandomByteGenerator::hex
+	 * @covers Keygen\Generator::keygen
 	 * @covers Keygen\Generator::generate
 	 */
 	public function testKeyGeneration()

--- a/tests/Keygen/Generators/TokenGeneratorTest.php
+++ b/tests/Keygen/Generators/TokenGeneratorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Keygen\Tests;
+
 use PHPUnit\Framework\TestCase;
 use Keygen\Generators\TokenGenerator;
 
@@ -16,7 +18,7 @@ final class TokenGeneratorTest extends TestCase
 	}
 
 	/**
-	 * @covers ::keygen
+	 * @covers Keygen\Generator::keygen
 	 * @covers Keygen\Generator::generate
 	 */
 	public function testKeyGeneration()

--- a/tests/Keygen/KeygenTest.php
+++ b/tests/Keygen/KeygenTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Keygen\Tests;
+
 use Keygen\Keygen;
 use PHPUnit\Framework\TestCase;
 use Keygen\Generators\TokenGenerator;
@@ -31,9 +33,6 @@ final class KeygenTest extends TestCase
 	}
 
 	/**
-	 * @covers ::__call
-	 * @covers ::newGenerator
-	 * @covers ::newGeneratorFromAlias
 	 * @covers Keygen\GeneratorFactory::create
 	 * @covers Keygen\AbstractGenerator::__call
 	 * @covers Keygen\AbstractGenerator::__callStatic
@@ -62,9 +61,6 @@ final class KeygenTest extends TestCase
 	}
 
 	/**
-	 * @covers ::__call
-	 * @covers ::newGenerator
-	 * @covers ::newGeneratorFromAlias
 	 * @covers Keygen\GeneratorFactory::create
 	 * @covers Keygen\AbstractGenerator::__call
 	 * @covers Keygen\AbstractGenerator::__callStatic


### PR DESCRIPTION
# Changed log
- Let this package require `php-5.5+` version at least because `php-5.4` is too old and outdated.
- It looks like the `ext-openssl` is required before `php-7.0` version, define the suggested extension to notice the users.
- Initialize Travis CI build. The build log is available [here](https://travis-ci.org/peter279k/keygen-php/builds/479531922).
- Set the current `@covers` and `@use` annotations to do the completed unit tests without warnings.
- Set the different PHPUnit versions to support multiple PHP versions.